### PR TITLE
WIP 0.7.2 Compatibility

### DIFF
--- a/lua/mind/commands.lua
+++ b/lua/mind/commands.lua
@@ -542,8 +542,8 @@ end
 -- Open and display a tree in a new window.
 M.open_tree = function(tree, data_dir, opts)
   -- window
-  vim.api.nvim_cmd({ cmd = 'vsp'}, {})
-  vim.api.nvim_cmd({ cmd = 'wincmd', args = { 'H' } }, {})
+  vim.api.nvim_exec("vsp", false)
+  vim.api.nvim_exec("wincmd H", false)
   vim.api.nvim_win_set_width(0, opts.ui.width)
 
   -- buffer


### PR DESCRIPTION
Swaps `nvim_cmd` for `nvim_exec`.

Checked for other incompatible calls in 0.7.2 with the following. 

```lua
local fname = "calls.txt"
-- via rg '(nvim_[_a-zA-Z]*)' * -INor '' > calls.txt
for line in io.lines("calls.txt") do
  if not vim.api[line] then
    print("No match for vim.api." .. line)
  end
end
```