### PR TITLE
feat: remove keymaps

### DIFF
--- a/doc/mind.txt
+++ b/doc/mind.txt
@@ -834,6 +834,17 @@ For a given keymap, a table is associated for which the key are the actual key
 to press and the value are either a string representing the command name (see
 |mind-lua-api-commands-declarative|).
 
+To disable default keymaps set `keymaps.default_keymaps` to false. If you
+only want to disable a few keymaps set the key of the map to "nil" for the
+map in `keymaps.normal` or `keymaps.selection`. The quotes around nil are
+required.
+
+-- disable tab in normal mode
+normal = {
+    ["<tab>"] = "nil"
+}
+
+
 Default:~
     normal = {
       ["<cr>"] = "open_data",
@@ -868,6 +879,9 @@ Default:~
       q = "quit",
       x = "select",
     }
+
+    -- boolean, set to false to remove all default keymaps
+    default_keymaps = true, 
 
 ==============================================================================
 HIGHLIGHTS                                                     *mind-highlights*

--- a/lua/mind/defaults.lua
+++ b/lua/mind/defaults.lua
@@ -161,5 +161,8 @@ return {
       q = 'quit',
       x = 'select',
     },
+
+    -- set to false to disable the default keymaps
+    default_keymaps = true,
   }
 }

--- a/lua/mind/init.lua
+++ b/lua/mind/init.lua
@@ -49,7 +49,22 @@ local function create_user_commands()
 end
 
 M.setup = function(opts)
-  M.opts = vim.tbl_deep_extend('force', require'mind.defaults', opts or {})
+  local defaults = require'mind.defaults'
+  local default_keymaps = defaults.keymaps.default_keymaps
+  -- check if user explicitly set default_keymaps
+  if opts and opts.keymaps and opts.keymaps.default_keymaps ~= nil then
+    default_keymaps = opts.keymaps.default_keymaps
+  end
+  -- Only disable if user explicitly set default_keymaps to false
+  if default_keymaps then
+    -- use default maps extended with user maps
+    M.opts = vim.tbl_deep_extend('force', defaults, opts or {})
+  else
+    -- remove the default maps and extend with user maps
+    defaults.keymaps.normal = nil
+    defaults.keymaps.selection = nil
+    M.opts = vim.tbl_deep_extend('force', defaults, opts or {})
+  end
 
   -- ensure the paths are expanded
   mind_state.expand_opts_paths(M.opts)

--- a/lua/mind/keymap.lua
+++ b/lua/mind/keymap.lua
@@ -68,23 +68,17 @@ M.insert_keymaps = function(bufnr, get_tree, data_dir, save_tree, opts)
   }
 
   for key, _ in pairs(keyset) do
-    vim.keymap.set('n', key, function()
-      local keymap = M.get_keymap()
-
-      if (keymap == nil) then
-        notify('no active keymap', vim.log.levels.WARN)
-        return
-      end
-
+    local keymap = M.get_keymap()
+    -- Don't overwrite users default mapping if they arent using the keymap
+    if keymap ~= nil then
+      -- cmd of 'nil' means don't set the keymap
       local cmd = keymap[key]
-
-      if (cmd == nil) then
-        notify('no command bound to ' .. tostring(key), vim.log.levels.WARN)
-        return
+      if cmd and cmd ~= 'nil' then
+        vim.keymap.set('n', key, function()
+          cmd(args)
+        end, { buffer = bufnr, noremap = true, silent = true })
       end
-
-      cmd(args)
-    end, { buffer = bufnr, noremap = true, silent = true })
+    end
   end
 end
 


### PR DESCRIPTION
To easily remove unwanted keymaps add the option keymaps.remove_keymaps.
This option defaults to false and will do nothing.

Some people don't want any keymaps set. In this case set to true.
```
remove_keymaps = true
```

If you just want to disable a select few, provide a list
```
remove_keymaps = {"<tab>", "q"}
```

If you override a keymap but also include it in remove_keymaps then the key will still not be set.