### PR TITLE
fix: duplicate help tag

### DIFF
--- a/doc/mind.txt
+++ b/doc/mind.txt
@@ -175,7 +175,7 @@ Arguments:~
     {render} whether to render the tree again after the function has finished.
     {opts}   user-defined options.
 
-`mind.wrap_project_tree_fn(`                              *mind.wrap_main_tree_fn*
+`mind.wrap_project_tree_fn(`                              *mind.wrap_project_tree_fn*
   {f}`,`
   {global}`,`
   {render}`,`


### PR DESCRIPTION
`mind.wrap_project_tree_fn` was tagged as `mind.wrap_main_tree_fn`

This was causing an error when building with Nix:
```
error: builder for '/nix/store/bl25b2fx6andrqvqfznxb4yhwk4vjbkd-vimplugin-mind-nvim-latest.drv' failed with exit code 1;
       last 10 log lines:
       > source root is source
       > patching sources
       > configuring
       > building
       > installing
       > post-installation fixup
       > Executing vimPluginGenTags
       > Building help tags
       > Error detected while processing command line:
       > E154: Duplicate tag "mind.wrap_main_tree_fn" in file /nix/store/ppvfjbxzxs2gyps5b1fl98pvhjx4ajm7-vimplugin-mind-nvim-latest/./doc/mind.txtFailed to
 build help tags!
       For full logs, run 'nix log /nix/store/bl25b2fx6andrqvqfznxb4yhwk4vjbkd-vimplugin-mind-nvim-latest.drv'.
error: 1 dependencies of derivation '/nix/store/5px2qcjn7dbd8mihfyxfivjx841p1j0a-vim-pack-dir.drv' failed to build
error: 1 dependencies of derivation '/nix/store/r5c88g1swp06w1c3i72g68grp74ac6gp-neovim-master.drv' failed to build
error: 1 dependencies of derivation '/nix/store/74azjcksp0kgqjrhdfcnalb54257nm2k-home-manager-path.drv' failed to build
error: 1 dependencies of derivation '/nix/store/8i45yibw9222ql05nqzfav9b5pf4k9yv-home-manager-generation.drv' failed to build
```