### PR TITLE
Hide relative line numbers in mind buffer

### DIFF
--- a/lua/mind/ui.lua
+++ b/lua/mind/ui.lua
@@ -1,7 +1,7 @@
 -- Everything relating to the UI.
 local M = {}
 
-local mind_node = require'mind.node'
+local mind_node = require 'mind.node'
 
 -- A per-tree render cache.
 --
@@ -225,6 +225,7 @@ M.open_window = function(opts)
     vim.api.nvim_win_set_width(0, opts.ui.width)
     vim.api.nvim_win_set_buf(0, bufnr)
     vim.api.nvim_win_set_option(0, 'nu', false)
+    vim.api.nvim_win_set_option(0, 'rnu', false)
   end
 
   return bufnr

--- a/lua/mind/ui.lua
+++ b/lua/mind/ui.lua
@@ -1,7 +1,7 @@
 -- Everything relating to the UI.
 local M = {}
 
-local mind_node = require 'mind.node'
+local mind_node = require'mind.node'
 
 -- A per-tree render cache.
 --


### PR DESCRIPTION
# Issue
If someone like me sets relative line numbering, they are displayed in the mind buffer. I've added this code to hide those relative numbering.

## Before my changes (The issue)
![mind_nvim_before_changes](https://user-images.githubusercontent.com/14215698/200165390-21e5c1e2-3bb7-4c83-8e8f-eaa039468498.png)

## After Changes
![mind_nvim_after_changes](https://user-images.githubusercontent.com/14215698/200165403-628f5ffa-5c76-4382-8748-f7c8f8d2984a.png)
