### PR TITLE
fix: doc reference to MindOpenSmartProject

### DIFF
--- a/doc/mind.txt
+++ b/doc/mind.txt
@@ -90,7 +90,7 @@ customize how those commands work, have a look at |mind.setup|.
 
     See |mind.open_project| for further information.
 
-`:MindOpenSmartProject`                                         *:MindOpenProject*
+`:MindOpenSmartProject`                                    *:MindOpenSmartProject*
     Open the project tree, either local, global or prompt the user for which
     kind of project tree to create.
 


### PR DESCRIPTION
Thanks for the great project! I had an issue with mind.nvim's doc when running `:helptags`, so here's my fix.