### PR TITLE
feat: Mind window toggling

### DIFF
--- a/doc/mind.txt
+++ b/doc/mind.txt
@@ -85,17 +85,34 @@ customize how those commands work, have a look at |mind.setup|.
 
     See |mind.open_main| for further information.
 
+`:MindToggleMain`                                                *:MindToggleMain*
+    Toggle the main mind tree. Opens the tree if closed, closes the
+    tree if open.
+
+    See |mind.toggle_main| for further information.
+
 `:MindOpenProject` {global}                                     *:MindOpenProject*
     Open the project tree.
 
     See |mind.open_project| for further information.
 
-`:MindOpenSmartProject`                                         *:MindOpenSmartProject*
+`:MindToggleProject` {global}                                 *:MindToggleProject*
+    Toggle the project tree.
+
+    See |mind.toggle_project| for further information.
+
+
+`:MindOpenSmartProject`                                    *:MindOpenSmartProject*
     Open the project tree, either local, global or prompt the user for which
     kind of project tree to create.
 
     See |mind.open_smart_project| for further information.
 
+`:MindToggleSmartProject`                                *:MindToggleSmartProject*
+    Toggle the project tree, either local, global or prompt the user for which
+    kind of project tree to create.
+
+    See |mind.toggle_smart_project| for further information.
 
 `:MindReloadState`                                              *:MindReloadState*
     Reload Mind state for global and local trees.
@@ -106,6 +123,7 @@ customize how those commands work, have a look at |mind.setup|.
     Close project or main mind tree if open. Resets ui cache.
 
     See |mind.close| for further information.
+
                                                                   *mind-lua-api*
 Lua API~
 
@@ -150,6 +168,9 @@ Arguments:~
     for its state and |mind-config-persistence.data_dir| for any data
     associated with its nodes.
 
+`mind.toggle_main(``)`                                            *mind.toggle_main*
+    Toggle main mind tree.
+
 `mind.open_project(`{use_global}`)`                              *mind.open_project*
     Open the project Mind tree.
 
@@ -168,6 +189,15 @@ Arguments:~
     When working with a local tree, its data paths will always be relative to
     the |current-directory|, so that sharing such trees is easy (for instance,
     checking them in versionning systems like Git).
+
+Arguments:~
+    {global} Optional. `true` for a global project true, `false` or `nil`
+             otherwise.
+
+`mind.toggle_project(`{use_global}`)`                          *mind.toggle_project*
+    Toggle main mind tree.
+
+    See |mind.open_project|.
 
 Arguments:~
     {global} Optional. `true` for a global project true, `false` or `nil`

--- a/lua/mind/commands.lua
+++ b/lua/mind/commands.lua
@@ -761,6 +761,17 @@ M.close = function()
   mind_ui.render_cache = {}
 end
 
+-- Toggle the tree
+M.toggle = function(get_tree, data_dir, save_tree, opts)
+  if mind_ui.render_cache and mind_ui.render_cache.bufnr then
+    -- close the buffer if open
+    M.close()
+  else
+    -- open the buffer if closed
+    M.open_tree(get_tree, data_dir, save_tree, opts)
+  end
+end
+
 -- Precompute commands.
 --
 -- This function will scan the keymaps and will replace the command name with the real command function, if the command

--- a/lua/mind/init.lua
+++ b/lua/mind/init.lua
@@ -19,6 +19,16 @@ local function create_user_commands()
   )
 
   vim.api.nvim_create_user_command(
+    'MindToggleMain',
+    function()
+      require'mind'.toggle_main()
+    end,
+    {
+      desc = 'Toggle main or project Mind tree',
+    }
+  )
+
+  vim.api.nvim_create_user_command(
     'MindOpenProject',
     function(opts)
       require'mind'.open_project(opts.fargs[1] == 'global')
@@ -30,12 +40,33 @@ local function create_user_commands()
   )
 
   vim.api.nvim_create_user_command(
+    'MindToggleProject',
+    function(opts)
+      require'mind'.toggle_project(opts.fargs[1] == 'global')
+    end,
+    {
+      nargs = '?',
+      desc = 'Toggle the project Mind tree',
+    }
+  )
+
+  vim.api.nvim_create_user_command(
     'MindOpenSmartProject',
     function()
       require'mind'.open_smart_project()
     end,
     {
       desc = 'Open the project Mind tree',
+    }
+  )
+
+  vim.api.nvim_create_user_command(
+    'MindToggleSmartProject',
+    function()
+      require'mind'.toggle_smart_project()
+    end,
+    {
+      desc = 'Toggle the project Mind tree',
     }
   )
 
@@ -97,6 +128,21 @@ M.open_main = function()
   )
 end
 
+-- Toggle the main tree view.
+M.toggle_main = function()
+  M.wrap_main_tree_fn(
+    function(args)
+      mind_commands.toggle(
+        args.get_tree,
+        args.opts.persistence.data_dir,
+        function() mind_state.save_main_state(args.opts) end,
+        args.opts
+      )
+    end,
+    M.opts
+  )
+end
+
 -- Open a project tree.
 --
 -- If `use_global` is set to `true`, will use the global persistence location.
@@ -117,11 +163,46 @@ M.open_project = function(use_global)
   )
 end
 
+-- Toggle a project tree view.
+M.toggle_project = function(use_global)
+  M.wrap_project_tree_fn(
+    function(args)
+      mind_commands.toggle(
+        args.get_tree,
+        args.data_dir,
+        use_global
+          and function() mind_state.save_main_state(args.opts) end
+          or function() mind_state.save_local_state() end,
+        args.opts
+      )
+    end,
+    use_global,
+    M.opts
+  )
+end
+
 -- Open a smart project tree.
 M.open_smart_project = function()
   M.wrap_smart_project_tree_fn(
     function(args, use_global)
       mind_commands.open_tree(
+        args.get_tree,
+        args.data_dir,
+        use_global
+          and function() mind_state.save_main_state(args.opts) end
+          or function() mind_state.save_local_state() end,
+        args.opts
+      )
+    end,
+    M.opts
+  )
+end
+
+-- Toggle a smart project tree view.
+M.toggle_smart_project = function()
+  M.wrap_smart_project_tree_fn(
+    function(args, use_global)
+      mind_commands.toggle(
         args.get_tree,
         args.data_dir,
         use_global


### PR DESCRIPTION
Adding `MindToggleMain`, `MindToggleProject` and `MindToggleSmartProject` autocommands

Not sure about the implementation.
I was going for a similar approach as for `MindClose`, one autocommand to rule them all... but the window that we want to toggle can either be `Main`, `Project` or `SmartProject` so we can't assume which one should be toggled