### PR TITLE
feat: Delete file under cursor

### DIFF
--- a/doc/mind.txt
+++ b/doc/mind.txt
@@ -266,6 +266,9 @@ keys are documented here.
 `'delete'`                                                   *mind-command-delete*
     Delete the node under the cursor.
 
+`'delete_file'`                                         *mind-command-delete_file*
+    Delete the file associated with the node under the cursor.
+
 `'rename'`                                                   *mind-command-rename*
     Rename the node under the cursor.
 
@@ -873,6 +876,7 @@ Default:~
       l = "copy_node_link",
       L = "copy_node_link_index",
       d = "delete",
+      D = "delete_file",
       O = "add_above",
       o = "add_below",
       q = "quit",

--- a/lua/mind/commands.lua
+++ b/lua/mind/commands.lua
@@ -47,6 +47,10 @@ M.commands = {
     M.delete_node_cursor(args.get_tree(), args.save_tree, args.opts)
   end,
 
+  delete_file = function(args)
+    M.delete_data_cursor(args.get_tree(), args.save_tree, args.opts)
+  end,
+
   rename = function(args)
     M.rename_node_cursor(args.get_tree(), args.save_tree, args.opts)
   end,
@@ -157,6 +161,25 @@ M.open_data = function(tree, node, directory, save_tree, opts)
   end
 end
 
+-- Delete the data file associated with a node.
+--
+-- If it doesn’t exist, does nothing.
+M.delete_data = function(tree, node, save_tree, opts)
+  if (node.data == nil) then
+    notify('no files associated to this node', vim.log.levels.ERROR)
+    return
+  else
+    mind_ui.with_confirmation("Delete file?", function()
+      local file_path = node.data
+      mind_data.delete_data_file(file_path)
+      node.data = nil
+      mind_ui.rerender(tree, opts)
+      save_tree()
+      notify(string.format("file '%s' deleted", file_path), vim.log.levels.INFO)
+    end)
+  end
+end
+
 -- Open the data file associated with a node for the given line.
 --
 -- If it doesn’t exist, create it first.
@@ -175,6 +198,27 @@ end
 M.open_data_cursor = function(tree, directory, save_tree, opts)
   mind_ui.with_cursor(function(line)
     M.open_data_line(tree, line, directory, save_tree, opts)
+  end)
+end
+
+-- Delete the data file associated with a node for the given line.
+--
+-- If it doesn’t exist, create it first.
+M.delete_data_line = function(tree, line, save_tree, opts)
+  local node = mind_node.get_node_by_line(tree, line)
+
+  if (node == nil) then
+    notify('cannot delete data; no node', vim.log.levels.ERROR)
+    return
+  end
+
+  M.delete_data(tree, node, save_tree, opts)
+end
+
+-- Deletes the data file associated with the node under the cursor.
+M.delete_data_cursor = function(tree, save_tree, opts)
+  mind_ui.with_cursor(function(line)
+    M.delete_data_line(tree, line, save_tree, opts)
   end)
 end
 

--- a/lua/mind/data.lua
+++ b/lua/mind/data.lua
@@ -39,4 +39,10 @@ M.new_data_file = function(dir, name, extension, content, should_expand)
   return file_path
 end
 
+-- Deletes the given file.
+M.delete_data_file = function(file_path)
+  os.remove(file_path)
+end
+
+
 return M

--- a/lua/mind/defaults.lua
+++ b/lua/mind/defaults.lua
@@ -139,6 +139,7 @@ return {
       l = 'copy_node_link',
       L = 'copy_node_link_index',
       d = 'delete',
+      D = 'delete_file',
       O = 'add_above',
       o = 'add_below',
       q = 'quit',


### PR DESCRIPTION
By default bound to `D` key, deletes the file associated to a node (if it exists) with a confirmation prompt
Should close https://github.com/phaazon/mind.nvim/issues/71