### PR TITLE
feat: close view on file open

### DIFF
--- a/doc/mind.txt
+++ b/doc/mind.txt
@@ -732,6 +732,12 @@ Default:~
 Default:~
     `width = 30`
 
+`ui.close_on_file_open`                        *mind-config-ui.close_on_file_open*
+    If `true` closes the mind window when a file is opened.
+
+Default:~
+    `close_on_file_open = false`
+
 `ui.root_marker`                                      *mind-config-ui.root_marker*
     Marker used to identify the root of the tree (left to its name).
 

--- a/lua/mind/commands.lua
+++ b/lua/mind/commands.lua
@@ -159,6 +159,10 @@ M.open_data = function(tree, node, directory, save_tree, opts)
     vim.api.nvim_set_current_win(winnr)
     vim.api.nvim_exec('e ' .. data, false)
   end
+
+    if opts.ui.close_on_file_open == true then
+        M.close()
+    end
 end
 
 -- Delete the data file associated with a node.

--- a/lua/mind/defaults.lua
+++ b/lua/mind/defaults.lua
@@ -51,6 +51,9 @@ return {
     -- default width of the tree view window
     width = 30,
 
+    -- should mind window be closed when a file is opened
+    close_on_file_open = false,
+
     -- marker used for empty indentation
     empty_indent_marker = '│',
 


### PR DESCRIPTION
It's just about closing the window when we open a file and focus is on the file instead of the mind window.
Thought it could be useful to someone, it's disabled by default.

Similar option as the one in `nvim-tree`