### PR TITLE
refactor(commands): autocmd id from callback table

### DIFF
--- a/lua/mind/commands.lua
+++ b/lua/mind/commands.lua
@@ -729,13 +729,12 @@ M.open_tree = function(get_tree, data_dir, save_tree, opts)
   local bufnr = mind_ui.open_window(opts)
 
   -- ensure that we close the tree if the window gets closed
-  local id
-  id = vim.api.nvim_create_autocmd(
+  vim.api.nvim_create_autocmd(
     { 'WinClosed' },
     {
       buffer = bufnr,
-      callback = function()
-        vim.api.nvim_del_autocmd(id)
+      callback = function(opts)
+        vim.api.nvim_del_autocmd(opts.id)
         M.close()
       end
     }


### PR DESCRIPTION
The `autocmd` is removed based on the value returned by the api. It surprised me that this worked. Any reason for doing that? Why not use the table passed to the callback to do that? From `h:nvim_create_autocmd`, a table provides indeed this information:

```help
     ...
 • callback (function|string) optional: if a string, the name
     ...
   autocommand; in addition, they accept a single table
   argument with the following keys:
   • id: (number) the autocommand id
    ...
```