### PR TITLE
feature: add default icon for new nodes

### DIFF
--- a/doc/mind.txt
+++ b/doc/mind.txt
@@ -790,7 +790,14 @@ Default:~
       { " ", "Monitoring" },
       { " ", "Internet, Earth, everyone!" },
       { " ", "Frozen, on-hold" },
+      { "  ", "None" },
     }
+
+`ui.default_icon`                                  *mind-config-ui.default_icon*
+    Default icon to add to new nodes.
+
+Default:~
+    `default_icon = nil`
 
                                                       *mind-config-ui-highlight*
 The `ui.highlight` sub-section is used to change the highlighting mechanism of

--- a/lua/mind/commands.lua
+++ b/lua/mind/commands.lua
@@ -319,6 +319,7 @@ end
 
 -- Add a node as child of another node.
 M.create_node = function(tree, grand_parent, parent, node, dir, opts)
+  mind_node.set_icon(node, opts.ui.default_icon)
   if (dir == mind_node.MoveDir.INSIDE_START) then
     mind_node.insert_node(parent, 1, node)
   elseif (dir == mind_node.MoveDir.INSIDE_END) then
@@ -438,11 +439,7 @@ end
 -- Change the icon of a node.
 M.change_icon = function(tree, node, save_tree, opts)
   mind_ui.with_input('Change icon: ', node.icon, function(input)
-    if input == ' ' then
-      input = nil
-    end
-
-    node.icon = input
+    mind_node.set_icon(node, input)
     mind_ui.rerender(tree, opts)
     save_tree()
   end)
@@ -475,11 +472,9 @@ M.change_icon_menu = function(tree, node, save_tree, opts)
       format_item = format_item
     },
     function(item)
-      if item ~= nil then
-        node.icon = item[1]
-        save_tree()
-        mind_ui.rerender(tree, opts)
-      end
+      mind_node.set_icon(node, item[1])
+      save_tree()
+      mind_ui.rerender(tree, opts)
     end
   )
 end

--- a/lua/mind/defaults.lua
+++ b/lua/mind/defaults.lua
@@ -123,7 +123,11 @@ return {
       { ' ', 'Monitoring' },
       { ' ', 'Internet, Earth, everyone!' },
       { ' ', 'Frozen, on-hold' },
-    }
+      { '  ', 'None' },
+    },
+
+    -- default icon for new nodes
+    default_icon = nil
   },
 
   -- default keymaps; see 'mind.commands' for a list of commands that can be mapped to keys here

--- a/lua/mind/node.lua
+++ b/lua/mind/node.lua
@@ -217,4 +217,13 @@ M.move_source_target_same_tree = function(tree, src, tgt)
   end
 end
 
+-- Set an icon for the node.
+M.set_icon = function(node, icon)
+  if icon == nil or icon:match("%S") == nil then
+    node.icon = nil
+  else
+    node.icon = icon
+  end
+end
+
 return M


### PR DESCRIPTION
Allow setting a default icon which will be set for any new node.   
Also allow to more easily reset the icon on an existing node by adding a `None` icon to the presets.

> I'm using mind.nvim mostly in the style of a TODO list and I'm tired of changing the icon to an empty checkbox every time I add a node.