### PR TITLE
Allow user to set (non-)expanded node marker

### DIFF
--- a/doc/mind.txt
+++ b/doc/mind.txt
@@ -738,6 +738,30 @@ Default:~
 Default:~
     `close_on_file_open = false`
 
+`ui.empty_indent_marker`                       *mind-config-ui.empty_indent_marker*
+    Marker used for empty indentation.
+
+Default:~
+    `empty_indent_marker = "│"`
+
+`ui.node_indent_marker`                        *mind-config-ui.node_indent_marker*
+    Marker used for node indentation.
+
+Default:~
+    `node_indent_marker = '└'`
+
+`ui.node_expanded_marker`                     *mind-config-ui.node_expanded_marker*
+    Marker used when node has children and is expanded.
+
+Default:~
+    `node_expanded_marker = ''`
+
+`ui.node_unexpanded_marker`                 *mind-config-ui.node_unexpanded_marker*
+    Marker used when node has children and is not expanded.
+
+Default:~
+    `node_unexpanded_marker = ''`
+
 `ui.root_marker`                                      *mind-config-ui.root_marker*
     Marker used to identify the root of the tree (left to its name).
 

--- a/lua/mind/defaults.lua
+++ b/lua/mind/defaults.lua
@@ -60,6 +60,12 @@ return {
     -- marker used for node indentation
     node_indent_marker = '└',
 
+    -- marker used when node has children and is expanded
+    node_expanded_marker = '',
+
+    -- marker used when node has children and is not expanded
+    node_unexpanded_marker = '',
+
     -- marker used to identify the root of the tree (left to its name)
     root_marker = ' ',
 

--- a/lua/mind/ui.lua
+++ b/lua/mind/ui.lua
@@ -135,8 +135,8 @@ local function render_node(node, indent, is_last, lines, hls, opts)
 
   if (node.children ~= nil) then
     if (node.is_expanded) then
-      local mark = ' '
-      local hl_col_end = hl_col_start + #mark
+      local marker = opts.ui.node_expanded_marker .. ' '
+      local hl_col_end = hl_col_start + #marker
 
       hls[#hls + 1] = {
         group = 'MindOpenMarker',
@@ -145,7 +145,7 @@ local function render_node(node, indent, is_last, lines, hls, opts)
         col_end = hl_col_end
       }
 
-      lines[#lines + 1] = line .. mark .. name
+      lines[#lines + 1] = line .. marker .. name
 
       for _, hl in ipairs(partial_hls) do
         hl_col_start = hl_col_end
@@ -165,8 +165,8 @@ local function render_node(node, indent, is_last, lines, hls, opts)
       end
       render_node(node.children[#node.children], indent, true, lines, hls, opts)
     else
-      local mark = ' '
-      local hl_col_end = hl_col_start + #mark
+      local marker = opts.ui.node_unexpanded_marker .. ' '
+      local hl_col_end = hl_col_start + #marker
 
       hls[#hls + 1] = {
         group = 'MindClosedMarker',
@@ -175,7 +175,7 @@ local function render_node(node, indent, is_last, lines, hls, opts)
         col_end = hl_col_end
       }
 
-      lines[#lines + 1] = line .. mark .. name
+      lines[#lines + 1] = line .. marker .. name
 
       for _, hl in ipairs(partial_hls) do
         hl_col_start = hl_col_end


### PR DESCRIPTION
Gives users the option to set a marker for non-expanded and expanded nodes

Also added missing documentation for `empty_indent_marker` and `node_indent_marker`